### PR TITLE
Remove unnecessary check from VM_OC_NOT (#2622)

### DIFF
--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -68,20 +68,6 @@ vm_var_decl (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
 } /* vm_var_decl */
 
 /**
- * 'Logical NOT Operator' opcode handler.
- *
- * See also: ECMA-262 v5, 11.4.9
- *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
- */
-ecma_value_t
-opfunc_logical_not (ecma_value_t left_value) /**< left value */
-{
-  return ecma_make_boolean_value (!ecma_op_to_boolean (left_value));
-} /* opfunc_logical_not */
-
-/**
  * 'typeof' opcode handler.
  *
  * See also: ECMA-262 v5, 11.4.3

--- a/jerry-core/vm/opcodes.h
+++ b/jerry-core/vm/opcodes.h
@@ -79,9 +79,6 @@ ecma_value_t
 opfunc_instanceof (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_logical_not (ecma_value_t left_value);
-
-ecma_value_t
 opfunc_typeof (ecma_value_t left_value);
 
 void

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2080,14 +2080,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_NOT:
         {
-          result = opfunc_logical_not (left_value);
-
-          if (ECMA_IS_VALUE_ERROR (result))
-          {
-            goto error;
-          }
-
-          *stack_top_p++ = result;
+          *stack_top_p++ = ecma_make_boolean_value (!ecma_op_to_boolean (left_value));
+          JERRY_ASSERT (ecma_is_value_boolean (stack_top_p[-1]));
           goto free_left_value;
         }
         case VM_OC_BIT_NOT:


### PR DESCRIPTION
This patch removes the ECMA_IS_VALUE_ERROR check from VM_OC_NOT, since the general toBoolean operation cannot throw an exception.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu